### PR TITLE
Respect the lower bound of the background in `SensEst`

### DIFF
--- a/darklim/sensitivity/_sens_est.py
+++ b/darklim/sensitivity/_sens_est.py
@@ -350,6 +350,7 @@ class SensEst(object):
             )
 
         e_high = en_interp.max()
+        e_low = en_interp.min()
         npts = len(en_interp)
 
         tot_bkgd = np.zeros(npts)
@@ -367,7 +368,7 @@ class SensEst(object):
         nevts_sim = np.random.poisson(nevts_exp)
 
         evts_sim = pdf_sampling(
-            tot_bkgd_func, (0, e_high), npoints=npts, nsamples=nevts_sim,
+            tot_bkgd_func, (e_low, e_high), npoints=npts, nsamples=nevts_sim,
         )
 
         if plot_bkgd:


### PR DESCRIPTION
Added a simple fix to ensure that the `pdf_sampling` function uses the correct lower bound, so the right amount of data is generated in the right range.