### PR TITLE
Small installation instruction patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,6 @@ To install the most recent development version of DarkLim from source, clone thi
 
 If using a shared Python installation, you may want to add the `--user` flag to the above line(s).
 
+Some functionality in this package requires [DarkELF](https://github.com/tongylin/DarkELF)  
+
 **NOTE:** This package also requires a Fortran compiler if installing from source (or a wheel is not available for your setup). We recommend installing `gfortran`, which can be done via `sudo apt-get install gfortran` on Linux or `brew install gcc` on macOS.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ setuptools<63
 mendeleev>=0.4.5
 scikit-learn>=0.20.2
 matplotlib>=2.2.2
+vegas


### PR DESCRIPTION
Hi! Added two lines to point to vegas and DarkElf. 

For DarkELF, I have opened https://github.com/tongylin/DarkELF/pull/2 since it was lacking a setup.py so I couldn't import it